### PR TITLE
Implement more strict value checking

### DIFF
--- a/pysesameos2/ble.py
+++ b/pysesameos2/ble.py
@@ -385,7 +385,11 @@ class CHBleManager:
 
         # `BLEDevice.metadata` should return device specific details in OS-agnostically way.
         # https://bleak.readthedocs.io/en/latest/api.html#bleak.backends.device.BLEDevice.metadata
-        if dev.metadata is None or "uuids" not in dev.metadata:
+        if (
+            dev.metadata is None
+            or "uuids" not in dev.metadata
+            or "manufacturer_data" not in dev.metadata
+        ):
             raise ValueError("Failed to find the device metadata")
 
         if SERVICE_UUID in dev.metadata["uuids"]:

--- a/pysesameos2/ble.py
+++ b/pysesameos2/ble.py
@@ -416,9 +416,6 @@ class CHBleManager:
                 bleak.BleakScanner.discover(), scan_duration
             )
 
-            if isinstance(devices, BLEDevice):
-                devices = [devices]
-
             for device in devices:
                 obj = self.device_factory(device)
                 if obj is not None:
@@ -461,18 +458,14 @@ class CHBleManager:
                 bleak.BleakScanner.discover(), scan_duration
             )
 
-            device = None
-            if isinstance(devices, BLEDevice) or devices is None:
-                device = devices
-            else:
-                device = next(
-                    (
-                        d
-                        for d in devices
-                        if d.address.lower() == ble_device_identifier.lower()
-                    ),
-                    None,
-                )
+            device = next(
+                (
+                    d
+                    for d in devices
+                    if d.address.lower() == ble_device_identifier.lower()
+                ),
+                None,
+            )
             if device is None:
                 raise ConnectionRefusedError("Scan completed: the device not found")
 

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -325,7 +325,30 @@ class TestCHBleManager:
                     ],
                     rssi=-60,
                     manufacturer_data={1370: b"\x00\x00\x01"},
-                )
+                ),
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:44:55:66",
+                    None,
+                    uuids=[
+                        "0000fd81-0000-1000-8000-00805f9b34fb",
+                    ],
+                    rssi=-60,
+                    manufacturer_data={1370: b"\x00\x00\x01"},
+                ),
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:77:88:99",
+                    "QpGK0YFUSv+9H/DN6IqN4Q",
+                    uuids=[
+                        "0000fd81-0000-1000-8000-00805f9b34fb",
+                    ],
+                    rssi=-60,
+                ),
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:AA:BB:CC",
+                    "QpGK0YFUSv+9H/DN6IqN4Q",
+                    rssi=-60,
+                    manufacturer_data={1370: b"\x02\x00\x01"},
+                ),
             ]
 
         bleak_scanner.discover.side_effect = _scan
@@ -333,7 +356,16 @@ class TestCHBleManager:
         with pytest.raises(ValueError):
             await CHBleManager().scan_by_address("AA:BB:CC:11:22:33")
 
-        bleak_scanner.discover.assert_called_once()
+        with pytest.raises(ValueError):
+            await CHBleManager().scan_by_address("AA:BB:CC:44:55:66")
+
+        with pytest.raises(ValueError):
+            await CHBleManager().scan_by_address("AA:BB:CC:77:88:99")
+
+        with pytest.raises(ValueError):
+            await CHBleManager().scan_by_address("AA:BB:CC:AA:BB:CC")
+
+        assert bleak_scanner.discover.call_count == 4
 
     @pytest.mark.asyncio
     async def test_CHBleManager_scan_by_address_returns_None_on_non_supported_device(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -301,7 +301,7 @@ class TestCHBleManager:
     ):
         async def _scan(*args, **kwargs):
             """Simulate a scanning response"""
-            return None
+            return []
 
         bleak_scanner.discover.side_effect = _scan
 
@@ -316,15 +316,17 @@ class TestCHBleManager:
     ):
         async def _scan(*args, **kwargs):
             """Simulate a scanning response"""
-            return bleak.backends.device.BLEDevice(
-                "AA:BB:CC:11:22:33",
-                "INVALID_NAME",
-                uuids=[
-                    "0000fd81-0000-1000-8000-00805f9b34fb",
-                ],
-                rssi=-60,
-                manufacturer_data={1370: b"\x00\x00\x01"},
-            )
+            return [
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:11:22:33",
+                    "INVALID_NAME",
+                    uuids=[
+                        "0000fd81-0000-1000-8000-00805f9b34fb",
+                    ],
+                    rssi=-60,
+                    manufacturer_data={1370: b"\x00\x00\x01"},
+                )
+            ]
 
         bleak_scanner.discover.side_effect = _scan
 
@@ -339,15 +341,17 @@ class TestCHBleManager:
     ):
         async def _scan(*args, **kwargs):
             """Simulate a scanning response"""
-            return bleak.backends.device.BLEDevice(
-                "AA:BB:CC:11:22:33",
-                "QpGK0YFUSv+9H/DN6IqN4Q",
-                uuids=[
-                    "0000fd81-0000-1000-8000-00805f9b34fb",
-                ],
-                rssi=-60,
-                manufacturer_data={1370: b"\x02\x00\x01"},
-            )
+            return [
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:11:22:33",
+                    "QpGK0YFUSv+9H/DN6IqN4Q",
+                    uuids=[
+                        "0000fd81-0000-1000-8000-00805f9b34fb",
+                    ],
+                    rssi=-60,
+                    manufacturer_data={1370: b"\x02\x00\x01"},
+                )
+            ]
 
         bleak_scanner.discover.side_effect = _scan
 
@@ -360,15 +364,17 @@ class TestCHBleManager:
     async def test_CHBleManager_scan_by_address(self, bleak_scanner):
         async def _scan(*args, **kwargs):
             """Simulate a scanning response"""
-            return bleak.backends.device.BLEDevice(
-                "AA:BB:CC:11:22:33",
-                "QpGK0YFUSv+9H/DN6IqN4Q",
-                uuids=[
-                    "0000fd81-0000-1000-8000-00805f9b34fb",
-                ],
-                rssi=-60,
-                manufacturer_data={1370: b"\x00\x00\x01"},
-            )
+            return [
+                bleak.backends.device.BLEDevice(
+                    "AA:BB:CC:11:22:33",
+                    "QpGK0YFUSv+9H/DN6IqN4Q",
+                    uuids=[
+                        "0000fd81-0000-1000-8000-00805f9b34fb",
+                    ],
+                    rssi=-60,
+                    manufacturer_data={1370: b"\x00\x00\x01"},
+                )
+            ]
 
         bleak_scanner.discover.side_effect = _scan
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -92,9 +92,9 @@ class TestCHSesame2MechStatus:
         )
 
     def test_CHSesame2MechStatus_rawdata_lowpower(self):
-        status = CHSesame2MechStatus(rawdata="48030080f3ff0002")
-        assert status.getBatteryPrecentage() == 78
-        assert status.getBatteryVoltage() == 5.912023460410557
+        status = CHSesame2MechStatus(rawdata="30030080f3ff0002")
+        assert status.getBatteryPrecentage() == 44
+        assert status.getBatteryVoltage() == 5.743108504398827
 
         status2 = CHSesame2MechStatus(rawdata="48020080f3ff0002")
         assert status2.getBatteryPrecentage() == 0


### PR DESCRIPTION
I am not sure know why, but the device information returned by `bleak` is often incomplete.
We'll do a more stringent value check to be sure and encourage retries.