### PR TITLE
Support SESAME bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ To be honest, this is my first time to use [`Bleak`](https://github.com/hbldh/bl
 * macOS 10.15.7, Python 3.9.5
 * Raspberry Pi Zero W (Raspbian GNU/Linux 10, Raspberry Pi reference 2021-05-07), Python 3.7.3
 
-## Features
+## Supported devices
 
-Please note that `pysesameos2` can only control [SESAME 3 Smart Lock](https://jp.candyhouse.co/products/sesame3) at this moment. Although all types of devices running Sesame OS2 are technically supportable, I don't actually have or need those devices. PRs are always welcome to help out!
+- [SESAME 3](https://jp.candyhouse.co/products/sesame3)
+- [SESAME bot](https://jp.candyhouse.co/products/sesame3-bot)
+
+## Features
 
 * Scan all SESAME locks using BLE advertisements.
 * Receive state changes (locked, handle position, etc.) that are actively reported from the device.
@@ -43,5 +46,6 @@ Please take a look at the [`example`](https://github.com/mochipon/pysesameos2/tr
 
 ## Credits & Thanks
 
-* A huge thank you to all at [CANDY HOUSE](https://jp.candyhouse.co/).
+* A huge thank you to all at [CANDY HOUSE](https://jp.candyhouse.co/) and their crowdfunding contributors!
+* Thanks to [@Chabiichi](https://github.com/Chabiichi)-san for [the offer](https://github.com/mochipon/pysesame3/issues/25) to get my SESAME bot!
 * Many thanks to [bleak](https://github.com/hbldh/bleak) and [pyzerproc](https://github.com/emlove/pyzerproc).

--- a/pysesameos2/ble.py
+++ b/pysesameos2/ble.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import logging
 import uuid
-from datetime import datetime
 from typing import Dict, Optional, Tuple, Union
 
 from bleak import BleakScanner
@@ -18,11 +17,7 @@ from pysesameos2.const import (
     BlePacketType,
 )
 from pysesameos2.device import CHDevices
-from pysesameos2.helper import (
-    CHProductModel,
-    CHSesame2MechSettings,
-    CHSesame2MechStatus,
-)
+from pysesameos2.helper import CHProductModel
 
 logger = logging.getLogger(__name__)
 
@@ -292,38 +287,6 @@ class CHSesame2BleResponse:
         return self._payload
 
 
-class CHSesame2BleLoginResponse:
-    def __init__(self, data: bytes) -> None:
-        """A representation of a response for login operation.
-
-        Args:
-            data (bytes): The rawdata.
-        """
-        if not isinstance(data, bytes):
-            raise TypeError("Invalid data")
-
-        self._systemTime = datetime.fromtimestamp(int.from_bytes(data[0:4], "little"))
-        # ??? data[4:8]
-        self._SSM2MechSetting = CHSesame2MechSettings(rawdata=data[8:20])
-        self._SSM2MechStatus = CHSesame2MechStatus(rawdata=data[20:28])
-
-    def getMechSetting(self) -> CHSesame2MechSettings:
-        """Return a mechanical setting of a device.
-
-        Returns:
-            CHSesame2MechSettings: The mechanical settinng.
-        """
-        return self._SSM2MechSetting
-
-    def getMechStatus(self) -> CHSesame2MechStatus:
-        """Return a mechanical status of a device.
-
-        Returns:
-            CHSesame2MechStatus: The mechanical status.
-        """
-        return self._SSM2MechStatus
-
-
 class BLEAdvertisement:
     def __init__(self, dev: BLEDevice, manufacturer_data: dict) -> None:
         if not isinstance(dev, BLEDevice):
@@ -394,11 +357,6 @@ class CHBleManager:
 
         if SERVICE_UUID in dev.metadata["uuids"]:
             adv = BLEAdvertisement(dev, dev.metadata["manufacturer_data"])
-
-            # TODO: Support other devices.
-            if adv.getProductModel() != CHProductModel.SS2:
-                raise NotImplementedError("The device is not supported!")
-
             device = adv.getProductModel().deviceFactory()()
             device.setAdvertisement(adv)
 

--- a/pysesameos2/chsesame2.py
+++ b/pysesameos2/chsesame2.py
@@ -30,6 +30,7 @@ from pysesameos2.const import (
 from pysesameos2.crypto import AppKeyFactory, BleCipher
 from pysesameos2.device import CHSesameLock
 from pysesameos2.helper import (
+    CHProductModel,
     CHSesame2MechSettings,
     CHSesame2MechStatus,
     HistoryTagHelper,
@@ -78,6 +79,7 @@ class CHSesame2(CHSesameLock):
     def __init__(self) -> None:
         """SESAME3 Device Specific Implementation."""
         super().__init__()
+        self.setProductModel(CHProductModel.SS2)
         self._rxBuffer = CHSesame2BleReceiver()
         self._txBuffer: Optional[CHSesame2BleTransmiter] = None
         self._mechStatus: Optional[CHSesame2MechStatus] = None

--- a/pysesameos2/chsesamebot.py
+++ b/pysesameos2/chsesamebot.py
@@ -1,6 +1,6 @@
 import asyncio
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from bleak import BleakClient
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class CHSesameBotBleLoginResponse:
     def __init__(self, data: bytes) -> None:
         """A representation of a response for login operation.
@@ -72,6 +73,7 @@ class CHSesameBotBleLoginResponse:
             CHSesameBotMechStatus: The mechanical status.
         """
         return self._SSM2MechStatus
+
 
 class CHSesameBot(CHSesameLock):
     def __init__(self) -> None:
@@ -115,13 +117,15 @@ class CHSesameBot(CHSesameLock):
         logger.debug(f"setMechStatus: {str(status)}")
         self._mechStatus = status
 
-        if self.getMechStatus().getMotorStatus() == 0:
+        if status is None:
+            self.setIntention(CHSesame2Intention.movingToUnknownTarget)
+        if status.getMotorStatus() == 0:
             self.setIntention(CHSesame2Intention.idle)
-        elif self.getMechStatus().getMotorStatus() == 1:
+        elif status.getMotorStatus() == 1:
             self.setIntention(CHSesame2Intention.locking)
-        elif self.getMechStatus().getMotorStatus() == 2:
+        elif status.getMotorStatus() == 2:
             self.setIntention(CHSesame2Intention.holding)
-        elif self.getMechStatus().getMotorStatus() == 3:
+        elif status.getMotorStatus() == 3:
             self.setIntention(CHSesame2Intention.unlocking)
         else:
             self.setIntention(CHSesame2Intention.movingToUnknownTarget)

--- a/pysesameos2/chsesamebot.py
+++ b/pysesameos2/chsesamebot.py
@@ -30,6 +30,7 @@ from pysesameos2.const import (
 from pysesameos2.crypto import AppKeyFactory, BleCipher
 from pysesameos2.device import CHSesameLock
 from pysesameos2.helper import (
+    CHProductModel,
     CHSesameBotMechSettings,
     CHSesameBotMechStatus,
     HistoryTagHelper,
@@ -79,6 +80,7 @@ class CHSesameBot(CHSesameLock):
     def __init__(self) -> None:
         """SESAME bot Device Specific Implementation."""
         super().__init__()
+        self.setProductModel(CHProductModel.SesameBot1)
         self._rxBuffer = CHSesame2BleReceiver()
         self._txBuffer: Optional[CHSesame2BleTransmiter] = None
         self._mechStatus: Optional[CHSesameBotMechStatus] = None
@@ -117,8 +119,6 @@ class CHSesameBot(CHSesameLock):
         logger.debug(f"setMechStatus: {str(status)}")
         self._mechStatus = status
 
-        if status is None:
-            self.setIntention(CHSesame2Intention.movingToUnknownTarget)
         if status.getMotorStatus() == 0:
             self.setIntention(CHSesame2Intention.idle)
         elif status.getMotorStatus() == 1:

--- a/pysesameos2/chsesamebot.py
+++ b/pysesameos2/chsesamebot.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 from datetime import datetime
+import logging
 from typing import TYPE_CHECKING, Optional
 
 from bleak import BleakClient
@@ -30,8 +30,8 @@ from pysesameos2.const import (
 from pysesameos2.crypto import AppKeyFactory, BleCipher
 from pysesameos2.device import CHSesameLock
 from pysesameos2.helper import (
-    CHSesame2MechSettings,
-    CHSesame2MechStatus,
+    CHSesameBotMechSettings,
+    CHSesameBotMechStatus,
     HistoryTagHelper,
 )
 
@@ -41,8 +41,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-class CHSesame2BleLoginResponse:
+class CHSesameBotBleLoginResponse:
     def __init__(self, data: bytes) -> None:
         """A representation of a response for login operation.
 
@@ -54,34 +53,34 @@ class CHSesame2BleLoginResponse:
 
         self._systemTime = datetime.fromtimestamp(int.from_bytes(data[0:4], "little"))
         # ??? data[4:8]
-        self._SSM2MechSetting = CHSesame2MechSettings(rawdata=data[8:20])
-        self._SSM2MechStatus = CHSesame2MechStatus(rawdata=data[20:28])
+        logger.info("mechSetting: {}".format(data[8:20].hex()))
+        self._SSM2MechSetting = CHSesameBotMechSettings(rawdata=data[8:20])
+        self._SSM2MechStatus = CHSesameBotMechStatus(rawdata=data[20:28])
 
-    def getMechSetting(self) -> CHSesame2MechSettings:
+    def getMechSetting(self) -> CHSesameBotMechSettings:
         """Return a mechanical setting of a device.
 
         Returns:
-            CHSesame2MechSettings: The mechanical settinng.
+            CHSesameBotMechSettings: The mechanical settinng.
         """
         return self._SSM2MechSetting
 
-    def getMechStatus(self) -> CHSesame2MechStatus:
+    def getMechStatus(self) -> CHSesameBotMechStatus:
         """Return a mechanical status of a device.
 
         Returns:
-            CHSesame2MechStatus: The mechanical status.
+            CHSesameBotMechStatus: The mechanical status.
         """
         return self._SSM2MechStatus
 
-
-class CHSesame2(CHSesameLock):
+class CHSesameBot(CHSesameLock):
     def __init__(self) -> None:
-        """SESAME3 Device Specific Implementation."""
+        """SESAME bot Device Specific Implementation."""
         super().__init__()
         self._rxBuffer = CHSesame2BleReceiver()
         self._txBuffer: Optional[CHSesame2BleTransmiter] = None
-        self._mechStatus: Optional[CHSesame2MechStatus] = None
-        self._mechSetting: Optional[CHSesame2MechSettings] = None
+        self._mechStatus: Optional[CHSesameBotMechStatus] = None
+        self._mechSetting: Optional[CHSesameBotMechSettings] = None
         self._intention = CHSesame2Intention.idle
 
     def getRxBuffer(self) -> CHSesame2BleReceiver:
@@ -96,53 +95,52 @@ class CHSesame2(CHSesameLock):
     def setTxBuffer(self, ble_tx: CHSesame2BleTransmiter) -> None:
         self._txBuffer = ble_tx
 
-    def getMechStatus(self) -> Optional[CHSesame2MechStatus]:
+    def getMechStatus(self) -> Optional[CHSesameBotMechStatus]:
         """Return a mechanical status of a device.
 
         Returns:
-            CHSesame2MechStatus: Current mechanical status of the device.
+            CHSesameBotMechStatus: Current mechanical status of the device.
         """
         return self._mechStatus
 
-    def setMechStatus(self, status: CHSesame2MechStatus) -> None:
+    def setMechStatus(self, status: CHSesameBotMechStatus) -> None:
         """Set a mechanincal status of a device.
 
         Args:
-            status (CHSesame2MechStatus): Current mechanical status of the device.
+            status (CHSesameBotMechStatus): Current mechanical status of the device.
         """
-        if not isinstance(status, CHSesame2MechStatus):
+        if not isinstance(status, CHSesameBotMechStatus):
             raise TypeError("Invalid status")
 
         logger.debug(f"setMechStatus: {str(status)}")
         self._mechStatus = status
 
-        if status.getTarget() == -32768:
+        if self.getMechStatus().getMotorStatus() == 0:
             self.setIntention(CHSesame2Intention.idle)
+        elif self.getMechStatus().getMotorStatus() == 1:
+            self.setIntention(CHSesame2Intention.locking)
+        elif self.getMechStatus().getMotorStatus() == 2:
+            self.setIntention(CHSesame2Intention.holding)
+        elif self.getMechStatus().getMotorStatus() == 3:
+            self.setIntention(CHSesame2Intention.unlocking)
         else:
-            setting = self.getMechSetting()
+            self.setIntention(CHSesame2Intention.movingToUnknownTarget)
 
-            if setting is None:
-                self.setIntention(CHSesame2Intention.movingToUnknownTarget)
-            elif status.getTarget() == setting.getLockPosition():
-                self.setIntention(CHSesame2Intention.locking)
-            elif status.getTarget() == setting.getUnlockPosition():
-                self.setIntention(CHSesame2Intention.unlocking)
-
-    def getMechSetting(self) -> Optional[CHSesame2MechSettings]:
+    def getMechSetting(self) -> Optional[CHSesameBotMechSettings]:
         """Return mechanical settings of a device
 
         Returns:
-            CHSesame2MechSettings: The mechanical settings of the device
+            CHSesameBotMechSettings: The mechanical settings of the device
         """
         return self._mechSetting
 
-    def setMechSetting(self, setting: CHSesame2MechSettings) -> None:
+    def setMechSetting(self, setting: CHSesameBotMechSettings) -> None:
         """Set mechanical settings of a device
 
         Args:
-            setting (CHSesame2MechSettings): The mechanical settings of the device
+            setting (CHSesameBotMechSettings): The mechanical settings of the device
         """
-        if not isinstance(setting, CHSesame2MechSettings):
+        if not isinstance(setting, CHSesameBotMechSettings):
             raise TypeError("Invalid setting")
 
         logger.debug(f"setMechSetting: {str(setting)}")
@@ -318,7 +316,7 @@ class CHSesame2(CHSesameLock):
                 response_payload.getCmdItCode() == BleItemCode.login
                 and response_payload.getCmdResultCode() == BleCmdResultCode.success
             ):
-                login_response = CHSesame2BleLoginResponse(
+                login_response = CHSesameBotBleLoginResponse(
                     response_payload.getPayload()
                 )
                 mech_setting = login_response.getMechSetting()
@@ -328,14 +326,11 @@ class CHSesame2(CHSesameLock):
                 self.setMechSetting(mech_setting)
                 logger.debug(f"onCharacteristicChanged: retrived {str(mech_status)}")
                 self.setMechStatus(mech_status)
-                if mech_setting.isConfigured:
-                    self.setDeviceStatus(
-                        CHSesame2Status.Locked
-                        if mech_status.isInLockRange()
-                        else CHSesame2Status.Unlocked
-                    )
-                else:
-                    self.setDeviceStatus(CHSesame2Status.NoSettings)
+                self.setDeviceStatus(
+                    CHSesame2Status.Locked
+                    if mech_status.isInLockRange()
+                    else CHSesame2Status.Unlocked
+                )
 
     async def onGattSesamePublish(self, publish_payload: CHSesame2BlePublish) -> None:
         if publish_payload.getCmdItCode() == BleItemCode.initial:
@@ -352,7 +347,7 @@ class CHSesame2(CHSesameLock):
             else:
                 await self.loginSesame()
         elif publish_payload.getCmdItCode() == BleItemCode.mechStatus:
-            received_mechstatus = CHSesame2MechStatus(
+            received_mechstatus = CHSesameBotMechStatus(
                 rawdata=publish_payload.getPayload()
             )
 
@@ -364,12 +359,31 @@ class CHSesame2(CHSesameLock):
                 else CHSesame2Status.Unlocked
             )
         elif publish_payload.getCmdItCode() == BleItemCode.mechSetting:
-            received_mechsetting = CHSesame2MechSettings(
+            received_mechsetting = CHSesameBotMechSettings(
                 rawdata=publish_payload.getPayload()
             )
 
             logger.debug(f"onGattSesamePublish: recieved {str(received_mechsetting)}")
             self.setMechSetting(received_mechsetting)
+
+    async def click(self, history_tag: str = "pysesameos2") -> None:
+        """Click.
+
+        Args:
+            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesameos2`.
+        """
+        if self.getDeviceStatus().value == CHDeviceLoginStatus.UnLogin:
+            raise RuntimeError("No device connenction.")
+
+        logger.info(f"Click: UUID={self.getDeviceUUID()}, history_tag={history_tag}")
+        await self.sendCommand(
+            CHSesame2BlePayload(
+                BleOpCode.async_,
+                BleItemCode.click,
+                HistoryTagHelper.create_htag(history_tag),
+            ),
+            BleCommunicationType.ciphertext,
+        )
 
     async def lock(self, history_tag: str = "pysesameos2") -> None:
         """Locking.
@@ -432,4 +446,4 @@ class CHSesame2(CHSesameLock):
         Returns:
             str: The string representation of the object.
         """
-        return f"CHSesame2(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, mechStatus={self.getMechStatus()})"
+        return f"CHSesameBot(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, mechStatus={self.getMechStatus()})"

--- a/pysesameos2/helper.py
+++ b/pysesameos2/helper.py
@@ -3,9 +3,9 @@ import sys
 from enum import Enum
 from typing import Generator, Union
 
-if sys.version_info[:2] >= (3, 8):
+if sys.version_info[:2] >= (3, 8):  # pragma: no cover
     from typing import TypedDict
-else:
+else:  # pragma: no cover
     from typing_extensions import TypedDict
 
 
@@ -17,7 +17,6 @@ class ProductData(TypedDict):
 
 
 class CHProductModel(Enum):
-
     WM2: ProductData = {
         "deviceModel": "wm_2",
         "isLocker": False,
@@ -30,6 +29,12 @@ class CHProductModel(Enum):
         "productType": 0,
         "deviceFactory": "CHSesame2",
     }
+    SesameBot1: ProductData = {
+        "deviceModel": "ssmbot_1",
+        "isLocker": True,
+        "productType": 2,
+        "deviceFactory": "CHSesameBot",
+    }
 
     @staticmethod
     def getByModel(model: str) -> "CHProductModel":
@@ -40,7 +45,9 @@ class CHProductModel(Enum):
                 e for e in list(CHProductModel) if e.value["deviceModel"] == model
             )
         except StopIteration:
-            raise NotImplementedError("This device is not supported.")
+            raise NotImplementedError(
+                "This device is not supported, unknown deviceModel: {}.".format(model)
+            )
 
     @staticmethod
     def getByValue(val: int) -> "CHProductModel":
@@ -51,7 +58,9 @@ class CHProductModel(Enum):
                 e for e in list(CHProductModel) if e.value["productType"] == val
             )
         except StopIteration:
-            raise NotImplementedError("This device is not supported.")
+            raise NotImplementedError(
+                "This device is not supported, unknown productType: {}.".format(val)
+            )
 
     def deviceModel(self) -> str:
         return self.value["deviceModel"]
@@ -64,7 +73,9 @@ class CHProductModel(Enum):
 
     def deviceFactory(self) -> type:
         if self.value["deviceFactory"] is None:
-            raise NotImplementedError("This device type is not supported.")
+            raise NotImplementedError(
+                "This device type is not supported, deviceFactory is missing."
+            )
         return getattr(
             importlib.import_module(
                 f"pysesameos2.{self.value['deviceFactory'].lower()}"
@@ -73,7 +84,7 @@ class CHProductModel(Enum):
         )
 
 
-class CHSesame2MechStatus:
+class CHSesameProtocolMechStatus:
     def __init__(self, rawdata: Union[bytes, str]) -> None:
         """Represent a mechanical status of a device.
 
@@ -85,19 +96,16 @@ class CHSesame2MechStatus:
         elif isinstance(rawdata, bytes):
             data = rawdata
         else:
-            raise TypeError("Invalid CHSesame2MechStatus")
+            raise TypeError("Invalid SesameProtocolMechStatus")
 
         self._data = data
         self._batteryVoltage = int.from_bytes(data[0:2], "little") * 7.2 / 1023
-        self._target = int.from_bytes(data[2:4], "little", signed=True)
-        self._position = int.from_bytes(data[4:6], "little", signed=True)
-        self._retcode = data[6]
-        self._isInLockRange = data[7] & 2 > 0
-        self._isInUnlockRange = data[7] & 4 > 0
-        self._isBatteryCritical = data[7] & 32 > 0
-
-    def __str__(self) -> str:
-        return f"CHSesame2MechStatus(Battery={self.getBatteryPrecentage()}% ({self.getBatteryVoltage():.2f}V), isInLockRange={self.isInLockRange()}, isInUnlockRange={self.isInUnlockRange()}, Position={self.getPosition()})"
+        self._target: int
+        self._position: int
+        self._retcode: int
+        self._isInLockRange: bool
+        self._isInUnlockRange: bool
+        self._isBatteryCritical: bool
 
     def getBatteryPrecentage(self) -> int:
         """Return battery status information as a percentage.
@@ -178,9 +186,35 @@ class CHSesame2MechStatus:
         return self._isInUnlockRange
 
 
+class CHSesame2MechStatus(CHSesameProtocolMechStatus):
+    def __init__(self, rawdata: Union[bytes, str]) -> None:
+        """Represent a mechanical status of a SESAME3.
+
+        Args:
+            rawdata (Union[bytes, str]): The rawdata from the device.
+        """
+        if isinstance(rawdata, str):
+            data = bytes.fromhex(rawdata)
+        elif isinstance(rawdata, bytes):
+            data = rawdata
+        else:
+            raise TypeError("Invalid CHSesame2MechStatus")
+
+        super().__init__(rawdata=data)
+        self._target = int.from_bytes(data[2:4], "little", signed=True)
+        self._position = int.from_bytes(data[4:6], "little", signed=True)
+        self._retcode = data[6]
+        self._isInLockRange = data[7] & 2 > 0
+        self._isInUnlockRange = data[7] & 4 > 0
+        self._isBatteryCritical = data[7] & 32 > 0
+
+    def __str__(self) -> str:
+        return f"CHSesame2MechStatus(Battery={self.getBatteryPrecentage()}% ({self.getBatteryVoltage():.2f}V), isInLockRange={self.isInLockRange()}, isInUnlockRange={self.isInUnlockRange()}, Position={self.getPosition()})"
+
+
 class CHSesame2MechSettings:
     def __init__(self, rawdata: Union[bytes, str]) -> None:
-        """Represent mechanical setting of a device.
+        """Represent mechanical setting of a SESAME3.
 
         Args:
             rawdata (Union[bytes, str]): The rawdata from the device.
@@ -206,23 +240,158 @@ class CHSesame2MechSettings:
         return self.getLockPosition() != self.getUnlockPosition()
 
     def getLockPosition(self) -> int:
-        """Return an angle of a key to be locked.
+        """Return an angle of a lock to be locked.
 
         Returns:
-            int: The key position (-32767~0~32767)
+            int: The lock position (-32767~0~32767)
         """
         return self._lockPosition
 
     def getUnlockPosition(self) -> int:
-        """Return an angle of a key to be unlocked.
+        """Return an angle of a lock to be unlocked.
 
         Returns:
-            int: The key position (-32767~0~32767)
+            int: The lock position (-32767~0~32767)
         """
         return self._unlockPosition
 
     def __str__(self) -> str:
         return f"CHSesame2MechSettings(LockPosition={self.getLockPosition()}, UnlockPosition={self.getUnlockPosition()}, isConfigured={self.isConfigured})"
+
+
+class CHSesameBotMechStatus(CHSesameProtocolMechStatus):
+    def __init__(self, rawdata: Union[bytes, str]) -> None:
+        """Represent a mechanical status of a SESAME bot.
+
+        Args:
+            rawdata (Union[bytes, str]): The rawdata from the device.
+        """
+        if isinstance(rawdata, str):
+            data = bytes.fromhex(rawdata)
+        elif isinstance(rawdata, bytes):
+            data = rawdata
+        else:
+            raise TypeError("Invalid CHSesameBotMechStatus")
+
+        super().__init__(rawdata=data)
+        self._motorStatus = data[4]
+        self._isInLockRange = data[7] & 2 > 0
+        self._isInUnlockRange = data[7] & 4 > 0
+        self._isBatteryCritical = data[7] & 32 > 0
+
+    def getMotorStatus(self) -> int:
+        return self._motorStatus
+
+    def __str__(self) -> str:
+        return f"CHSesameBotMechStatus(Battery={self.getBatteryPrecentage()}% ({self.getBatteryVoltage():.2f}V), motorStatus={self.getMotorStatus()})"
+
+
+class CHSesameBotMechSettings:
+    def __init__(self, rawdata: Union[bytes, str]) -> None:
+        """Represent mechanical setting of a SESAME bot.
+
+        Args:
+            rawdata (Union[bytes, str]): The rawdata from the device.
+        """
+        if isinstance(rawdata, str):
+            data = bytes.fromhex(rawdata)
+        elif isinstance(rawdata, bytes):
+            data = rawdata
+        else:
+            raise TypeError("Invalid CHSesameBotMechSettings")
+
+        self._data = data
+        self._userPrefDir = CHSesameBotUserPreDir(bytes([data[0]]))
+        self._lockSecConfig = CHSesameBotLockSecondsConfiguration(rawdata=data[1:6])
+        self._buttonMode = CHSesameBotButtonMode(bytes([data[6]]))
+
+    def getButtonMode(self) -> "CHSesameBotButtonMode":
+        return self._buttonMode
+
+    def getLockSecConfig(self) -> "CHSesameBotLockSecondsConfiguration":
+        return self._lockSecConfig
+
+    def getUserPrefDir(self) -> "CHSesameBotUserPreDir":
+        return self._userPrefDir
+
+    def __str__(self) -> str:
+        return f"CHSesameBotMechSettings(userPrefDir={self.getUserPrefDir()}, lockSec={self.getLockSecConfig().getLockSec()}, unlockSec={self.getLockSecConfig().getUnlockSec()}, clickLockSec={self.getLockSecConfig().getClickLockSec()}, clickHoldSec={self.getLockSecConfig().getClickHoldSec()}, clickUnlockSec={self.getLockSecConfig().getClickUnlockSec()}, buttonMode={self.getButtonMode()})"
+
+
+class CHSesameBotUserPreDir(Enum):
+    """Represent an arm rotation direction in a SESAME bot."""
+
+    normal = bytes([0])
+    reversed = bytes([1])
+
+
+class CHSesameBotLockSecondsConfiguration:
+    def __init__(self, rawdata: Union[bytes, str]) -> None:
+        """Represent detailed time settings for various actions of a SESAME bot.
+
+        Args:
+            rawdata (Union[bytes, str]): The rawdata from the device.
+        """
+        if isinstance(rawdata, str):
+            data: bytes = bytes.fromhex(rawdata)
+        elif isinstance(rawdata, bytes):
+            data = rawdata
+        else:
+            raise TypeError("Invalid CHSesameBotLockSecondsConfiguration")
+
+        self._data = data
+        self._lockSec = int.from_bytes([data[0]], "little")
+        self._unlockSec = int.from_bytes([data[1]], "little")
+        self._clickLockSec = int.from_bytes([data[2]], "little")
+        self._clickHoldSec = int.from_bytes([data[3]], "little")
+        self._clickUnlockSec = int.from_bytes([data[4]], "little")
+
+    def getLockSec(self) -> int:
+        """Return a number of seconds taken to rotate forward.
+
+        Returns:
+            int: The number of seconds.
+        """
+        return self._lockSec
+
+    def getUnlockSec(self) -> int:
+        """Return a number of seconds taken to rotate backwards.
+
+        Returns:
+            int: The number of seconds.
+        """
+        return self._unlockSec
+
+    def getClickLockSec(self) -> int:
+        """Return a number of seconds taken to rotate forward in click mode.
+
+        Returns:
+            int: The number of seconds.
+        """
+        return self._clickLockSec
+
+    def getClickHoldSec(self) -> int:
+        """Return a number of seconds taken to hold position in click mode.
+
+        Returns:
+            int: The number of seconds.
+        """
+        return self._clickHoldSec
+
+    def getClickUnlockSec(self) -> int:
+        """Return a number of seconds taken to rotate backwards in click mode.
+
+        Returns:
+            int: The number of seconds.
+        """
+        return self._clickUnlockSec
+
+
+class CHSesameBotButtonMode(Enum):
+    """Represent a button mode of a SESAME bot."""
+
+    click = bytes([0])
+    toggle = bytes([1])
 
 
 class HistoryTagHelper:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -12,7 +12,6 @@ from bleak.exc import BleakError
 from pysesameos2.ble import (
     BLEAdvertisement,
     CHBleManager,
-    CHSesame2BleLoginResponse,
     CHSesame2BleNotify,
     CHSesame2BlePayload,
     CHSesame2BlePublish,
@@ -172,27 +171,6 @@ class TestCHSesame2BleResponse:
         assert r.getPayload() == bytes(0)
 
 
-class TestCHSesame2BleLoginResponse:
-    def test_CHSesame2BleLoginResponse_raises_exception_on_missing_arguments(self):
-        with pytest.raises(TypeError):
-            CHSesame2BleLoginResponse()
-
-    def test_CHSesame2BleLoginResponse_raises_exception_on_invalid_arguments(self):
-        with pytest.raises(TypeError):
-            CHSesame2BleLoginResponse("INVALID-DATA")
-
-    def test_CHSesame2BleLoginResponse(self):
-        r = CHSesame2BleLoginResponse(
-            bytes.fromhex("f545d36001008001e30105034d0179026f029b035e03008016020002")
-        )
-
-        assert isinstance(r.getMechStatus(), CHSesame2MechStatus)
-        assert r.getMechStatus().isInLockRange()
-
-        assert isinstance(r.getMechSetting(), CHSesame2MechSettings)
-        assert r.getMechSetting().isConfigured
-
-
 class TestBLEAdvertisement:
     def test_BLEAdvertisement_raises_exception_on_missing_arguments(self):
         with pytest.raises(TypeError):
@@ -248,7 +226,7 @@ class TestCHBleManager:
                 "0000fd81-0000-1000-8000-00805f9b34fb",
             ],
             rssi=-60,
-            manufacturer_data={1370: b"\x02\x00\x01"},
+            manufacturer_data={1370: b"\xff\x00\x01"},
         )
 
         with pytest.raises(NotImplementedError):
@@ -280,7 +258,7 @@ class TestCHBleManager:
                         "0000fd81-0000-1000-8000-00805f9b34fb",
                     ],
                     rssi=-60,
-                    manufacturer_data={1370: b"\x02\x00\x01"},
+                    manufacturer_data={1370: b"\xff\x00\x01"},
                 ),
                 BLEDevice(
                     "AA:BB:CC:44:55:66",
@@ -444,7 +422,7 @@ class TestCHBleManager:
                         "0000fd81-0000-1000-8000-00805f9b34fb",
                     ],
                     rssi=-60,
-                    manufacturer_data={1370: b"\x02\x00\x01"},
+                    manufacturer_data={1370: b"\xff\x00\x01"},
                 )
             ]
 

--- a/tests/test_chsesame2.py
+++ b/tests/test_chsesame2.py
@@ -11,7 +11,7 @@ from pysesameos2.ble import (
     CHSesame2BleReceiver,
     CHSesame2BleTransmiter,
 )
-from pysesameos2.chsesame2 import CHSesame2
+from pysesameos2.chsesame2 import CHSesame2, CHSesame2BleLoginResponse
 from pysesameos2.const import BleCommunicationType, CHSesame2Intention, CHSesame2Status
 from pysesameos2.crypto import BleCipher
 from pysesameos2.device import CHDeviceKey
@@ -21,6 +21,27 @@ if sys.version_info[:2] < (3, 8):
     from asynctest import patch
 else:
     from unittest.mock import patch
+
+
+class TestCHSesame2BleLoginResponse:
+    def test_CHSesame2BleLoginResponse_raises_exception_on_missing_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesame2BleLoginResponse()
+
+    def test_CHSesame2BleLoginResponse_raises_exception_on_invalid_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesame2BleLoginResponse("INVALID-DATA")
+
+    def test_CHSesame2BleLoginResponse(self):
+        r = CHSesame2BleLoginResponse(
+            bytes.fromhex("f545d36001008001e30105034d0179026f029b035e03008016020002")
+        )
+
+        assert isinstance(r.getMechStatus(), CHSesame2MechStatus)
+        assert r.getMechStatus().isInLockRange()
+
+        assert isinstance(r.getMechSetting(), CHSesame2MechSettings)
+        assert r.getMechSetting().isConfigured
 
 
 class TestCHSesame2:

--- a/tests/test_chsesame2.py
+++ b/tests/test_chsesame2.py
@@ -242,6 +242,11 @@ class TestCHSesame2:
         )
         assert s.getDeviceStatus() == CHSesame2Status.Locked
 
+        assert (
+            str(s)
+            == "CHSesame2(deviceUUID=None, deviceModel=CHProductModel.SS2, mechStatus=CHSesame2MechStatus(Battery=100% (6.08V), isInLockRange=True, isInUnlockRange=False, Position=-13))"
+        )
+
     @pytest.mark.asyncio
     async def test_CHSesame2_onGattSesamePublish_mechSetting(self):
         s = CHSesame2()

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -236,6 +236,11 @@ class TestCHSesameBot:
         )
         assert s.getDeviceStatus() == CHSesame2Status.Locked
 
+        assert (
+            str(s)
+            == "CHSesameBot(deviceUUID=None, deviceModel=CHProductModel.SesameBot1, mechStatus=CHSesameBotMechStatus(Battery=100% (3.00V), motorStatus=0))"
+        )
+
     @pytest.mark.asyncio
     async def test_CHSesameBot_onGattSesamePublish_mechSetting(self):
         s = CHSesameBot()
@@ -266,6 +271,19 @@ class TestCHSesameBot:
         s = CHSesameBot()
         with pytest.raises(RuntimeError):
             await s.lock()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_click(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Unlocked)
+
+        assert (await s.click()) is None
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_click_raises_exception_on_no_device_connenction(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.click()
 
     @pytest.mark.asyncio
     async def test_CHSesameBot_lock(self):

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python
+
+"""Tests for `pysesameos2` package."""
+
+import sys
+
+import pytest
+
+from pysesameos2.ble import (
+    CHSesame2BlePublish,
+    CHSesame2BleReceiver,
+    CHSesame2BleTransmiter,
+)
+from pysesameos2.chsesamebot import CHSesameBot, CHSesameBotBleLoginResponse
+from pysesameos2.const import BleCommunicationType, CHSesame2Intention, CHSesame2Status
+from pysesameos2.crypto import BleCipher
+from pysesameos2.device import CHDeviceKey
+from pysesameos2.helper import CHSesameBotButtonMode, CHSesameBotMechSettings, CHSesameBotMechStatus, CHSesameBotUserPreDir
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest import patch
+else:
+    from unittest.mock import patch
+
+
+class TestCHSesameBotBleLoginResponse:
+    def test_CHSesameBotBleLoginResponse_raises_exception_on_missing_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBotBleLoginResponse()
+
+    def test_CHSesameBotBleLoginResponse_raises_exception_on_invalid_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBotBleLoginResponse("INVALID-DATA")
+
+    def test_CHSesameBotBleLoginResponse(self):
+        r = CHSesameBotBleLoginResponse(
+            bytes.fromhex("4b41fe6000008001010a0a0a140f0000000000005803000000000004")
+        )
+
+        assert isinstance(r.getMechStatus(), CHSesameBotMechStatus)
+        assert r.getMechStatus().getMotorStatus() == 0
+
+        assert isinstance(r.getMechSetting(), CHSesameBotMechSettings)
+        assert r.getMechSetting().getUserPrefDir() == CHSesameBotUserPreDir.reversed
+        assert r.getMechSetting().getLockSecConfig().getLockSec() == 10
+        assert r.getMechSetting().getLockSecConfig().getUnlockSec() == 10
+        assert r.getMechSetting().getLockSecConfig().getClickLockSec() == 10
+        assert r.getMechSetting().getLockSecConfig().getClickHoldSec() == 20
+        assert r.getMechSetting().getLockSecConfig().getClickUnlockSec() == 15
+        assert r.getMechSetting().getButtonMode() == CHSesameBotButtonMode.click
+
+class TestCHSesameBot:
+    def test_CHSesameBot_RxBuffer(self):
+        s = CHSesameBot()
+
+        ble_receiver = CHSesame2BleReceiver()
+
+        assert s.setRxBuffer(ble_receiver) is None
+        assert s.getRxBuffer() == ble_receiver
+
+    def test_CHSesameBot_TxBuffer(self):
+        s = CHSesameBot()
+
+        segment_type = BleCommunicationType.plaintext
+        data = bytes.fromhex("feedfeedfeedfeedfeedfeedfeedfeed")
+        ble_transmitter = CHSesame2BleTransmiter(segment_type, data)
+
+        assert s.setTxBuffer(ble_transmitter) is None
+        assert s.getTxBuffer() == ble_transmitter
+
+    def test_CHSesameBot_MechStatus_exception_on_emtry_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBotMechStatus()
+
+    def test_CHSesameBot_MechStatus_raises_exception_on_invalid_argument(self):
+        with pytest.raises(ValueError):
+            CHSesameBotMechStatus("INVALID")
+
+        with pytest.raises(TypeError):
+            CHSesameBotMechStatus(10)
+
+        s = CHSesameBot()
+        with pytest.raises(TypeError):
+            s.setMechStatus("INVALID")
+
+    def test_CHSesameBot_MechStatus_idle_as_initial_status(self):
+        s = CHSesameBot()
+        assert s.getIntention() == CHSesame2Intention.idle
+
+    def test_CHSesameBot_MechStatus_idle(self):
+        s = CHSesameBot()
+
+        status = CHSesameBotMechStatus("5703000000000004")
+        assert s.setMechStatus(status) is None
+        assert s.getMechStatus() == status
+        assert s.getIntention() == CHSesame2Intention.idle
+
+    def test_CHSesameBot_MechStatus_unlocking(self):
+        s = CHSesameBot()
+        s.setMechStatus(CHSesameBotMechStatus("5503000003000004"))
+
+        assert s.getIntention() == CHSesame2Intention.unlocking
+
+    def test_CHSesameBot_MechStatus_locking(self):
+        s = CHSesameBot()
+        s.setMechStatus(CHSesameBotMechStatus("5703000001000002"))
+
+        assert s.getIntention() == CHSesame2Intention.locking
+
+    def test_CHSesameBot_MechStatus_holding(self):
+        s = CHSesameBot()
+        s.setMechStatus(CHSesameBotMechStatus("5503000002000002"))
+
+        assert s.getIntention() == CHSesame2Intention.holding
+
+    def test_CHSesameBot_MechStatus_movingToUnknownTarget(self):
+        s = CHSesameBot()
+        s.setMechStatus(CHSesameBotMechStatus("550300000f000002"))
+
+        assert s.getIntention() == CHSesame2Intention.movingToUnknownTarget
+
+
+    def test_CHSesameBot_MechSetting_raises_exception_on_invalid_argument(self):
+        s = CHSesameBot()
+        with pytest.raises(TypeError):
+            s.setMechSetting("INVALID")
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_loginSesame(self):
+        s = CHSesameBot()
+        s.setSesameToken(bytes.fromhex("ffffffff"))
+
+        k = CHDeviceKey()
+        k.setSecretKey("34344f4734344b3534344f4934344f47")
+        k.setSesame2PublicKey(
+            "4beeaef8baabbd0198d606847364dfe3c324552d45fab9e538a1af8e04729279000644fce039621d3ae37303379c1114efbc8186bd7229093caae446751e7ef6"
+        )
+        s.setKey(k)
+
+        with patch("pysesameos2.chsesamebot.CHSesameBot.transmit") as transmit:
+
+            async def _transmit(*args, **kwargs):
+                pass
+
+            transmit.side_effect = _transmit
+            assert (await s.loginSesame()) is None
+
+    def test_CHSesameBot_onConnectionStateChange(self):
+        s = CHSesameBot()
+        assert s.onConnectionStateChange("BaseBleakClient") is None
+        assert s.getDeviceStatus() == CHSesame2Status.NoBleSignal
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onCharacteristicChanged_plaintext_publish(self):
+        s = CHSesameBot()
+        s.setRegistered(True)
+
+        with patch("pysesameos2.chsesamebot.CHSesameBot.loginSesame") as login_sesame:
+            assert (
+                await s.onCharacteristicChanged(10, bytearray.fromhex("03080effffffff"))
+            ) is None
+        login_sesame.assert_called_once()
+        assert s.getSesameToken().hex() == "ffffffff"
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onCharacteristicChanged_ciphertext_without_setCipher(self):
+        s = CHSesameBot()
+
+        assert (
+            await s.onCharacteristicChanged(
+                10, bytearray.fromhex("01ffffffffffffffffffffffffffffffffffffff")
+            )
+        ) is None
+
+        with pytest.raises(RuntimeError):
+            await s.onCharacteristicChanged(
+                10, bytearray.fromhex("04ffffffffffffffffffffffffffffffffff")
+            )
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onCharacteristicChanged_ciphertext_login_success(self):
+        s = CHSesameBot()
+
+        with patch("pysesameos2.crypto.BleCipher", spec=BleCipher) as ble_cipher:
+            s.setCipher(ble_cipher)
+            ble_cipher.decrypt.return_value = bytes.fromhex(
+                "07020500e845fe6000008001010a0a0a140f0000000000005503000000000004"
+            )
+
+            assert (
+                await s.onCharacteristicChanged(10, bytearray.fromhex("050702"))
+            ) is None
+            assert s.getIntention() == CHSesame2Intention.idle
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onGattSesamePublish_initial_with_non_registered_device(
+        self,
+    ):
+        s = CHSesameBot()
+        s.setRegistered(False)
+
+        publish_payload = CHSesame2BlePublish(bytes.fromhex("0effffffff"))
+
+        with pytest.raises(NotImplementedError):
+            await s.onGattSesamePublish(publish_payload)
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onGattSesamePublish_initial_with_registered_device(self):
+        s = CHSesameBot()
+        s.setRegistered(True)
+
+        publish_payload = CHSesame2BlePublish(bytes.fromhex("0effffffff"))
+
+        with patch("pysesameos2.chsesamebot.CHSesameBot.loginSesame") as login_sesame:
+            assert (await s.onGattSesamePublish(publish_payload)) is None
+        login_sesame.assert_called_once()
+
+        assert s.getSesameToken().hex() == "ffffffff"
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onGattSesamePublish_mechStatus(self):
+        s = CHSesameBot()
+
+        publish_payload = CHSesame2BlePublish(bytes.fromhex("515503000000000102"))
+
+        assert (await s.onGattSesamePublish(publish_payload)) is None
+        assert str(s.getMechStatus()) == str(
+            CHSesameBotMechStatus(rawdata="5503000000000102")
+        )
+        assert s.getDeviceStatus() == CHSesame2Status.Locked
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_onGattSesamePublish_mechSetting(self):
+        s = CHSesameBot()
+
+        publish_payload = CHSesame2BlePublish(
+            bytes.fromhex("50010a0a0a140f000000000000")
+        )
+
+        assert (await s.onGattSesamePublish(publish_payload)) is None
+        assert str(s.getMechSetting()) == str(
+            CHSesameBotMechSettings(rawdata="010a0a0a140f000000000000")
+        )
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_connect_raises_exception_before_setAdvertisement(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.connect()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_loginSesame_raises_exception_before_setSesameToken(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.loginSesame()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_lock_raises_exception_on_no_device_connenction(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.lock()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_lock(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Unlocked)
+
+        assert (await s.lock()) is None
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_unlock_raises_exception_on_no_device_connenction(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.unlock()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_unlock(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Locked)
+
+        assert (await s.unlock()) is None
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_toggle_raises_exception_on_no_device_connenction(self):
+        s = CHSesameBot()
+        with pytest.raises(RuntimeError):
+            await s.toggle()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_toggle_raises_exception_before_setMechStatus(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Locked)
+        with pytest.raises(RuntimeError):
+            await s.toggle()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_toggle_to_unlocking(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Locked)
+        s.setMechStatus(CHSesameBotMechStatus(rawdata="5503000000000102"))
+
+        with patch("pysesameos2.chsesamebot.CHSesameBot.unlock") as unlock:
+            assert (await s.toggle()) is None
+        unlock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_CHSesameBot_toggle_to_locking(self):
+        s = CHSesameBot()
+        s.setDeviceStatus(CHSesame2Status.Unlocked)
+        s.setMechStatus(CHSesameBotMechStatus(rawdata="5503000000000104"))
+
+        with patch("pysesameos2.chsesamebot.CHSesameBot.lock") as lock:
+            assert (await s.toggle()) is None
+        lock.assert_called_once()
+
+    # TODO: Develop tests for the methods which relate to BleakClient.

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -15,7 +15,12 @@ from pysesameos2.chsesamebot import CHSesameBot, CHSesameBotBleLoginResponse
 from pysesameos2.const import BleCommunicationType, CHSesame2Intention, CHSesame2Status
 from pysesameos2.crypto import BleCipher
 from pysesameos2.device import CHDeviceKey
-from pysesameos2.helper import CHSesameBotButtonMode, CHSesameBotMechSettings, CHSesameBotMechStatus, CHSesameBotUserPreDir
+from pysesameos2.helper import (
+    CHSesameBotButtonMode,
+    CHSesameBotMechSettings,
+    CHSesameBotMechStatus,
+    CHSesameBotUserPreDir,
+)
 
 if sys.version_info[:2] < (3, 8):
     from asynctest import patch
@@ -48,6 +53,7 @@ class TestCHSesameBotBleLoginResponse:
         assert r.getMechSetting().getLockSecConfig().getClickHoldSec() == 20
         assert r.getMechSetting().getLockSecConfig().getClickUnlockSec() == 15
         assert r.getMechSetting().getButtonMode() == CHSesameBotButtonMode.click
+
 
 class TestCHSesameBot:
     def test_CHSesameBot_RxBuffer(self):
@@ -119,7 +125,6 @@ class TestCHSesameBot:
 
         assert s.getIntention() == CHSesame2Intention.movingToUnknownTarget
 
-
     def test_CHSesameBot_MechSetting_raises_exception_on_invalid_argument(self):
         s = CHSesameBot()
         with pytest.raises(TypeError):
@@ -163,7 +168,9 @@ class TestCHSesameBot:
         assert s.getSesameToken().hex() == "ffffffff"
 
     @pytest.mark.asyncio
-    async def test_CHSesameBot_onCharacteristicChanged_ciphertext_without_setCipher(self):
+    async def test_CHSesameBot_onCharacteristicChanged_ciphertext_without_setCipher(
+        self,
+    ):
         s = CHSesameBot()
 
         assert (

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -72,10 +72,10 @@ class TestCHSesameProtocolMechStatus:
 
     def test_CHSesame2MechStatus(self):
         status = CHSesameProtocolMechStatus(rawdata="60030080f3ff0002")
-        assert status.getBatteryVoltage() == 6.0809384164222875
+        assert status.isInLockRange()
 
         status = CHSesameProtocolMechStatus(rawdata=bytes.fromhex("60030080f3ff0002"))
-        assert status.getBatteryVoltage() == 6.0809384164222875
+        assert status.isInLockRange()
 
 
 class TestCHSesame2MechStatus:
@@ -168,30 +168,38 @@ class TestCHSesameBotMechStatus:
         status = CHSesameBotMechStatus(rawdata="5503000000000102")
 
         assert status.getBatteryPrecentage() == 100.0
-        assert status.getBatteryVoltage() == 6.003519061583578
+        assert status.getBatteryVoltage() == 3.001759530791789
         assert status.isInLockRange()
         assert not status.isInUnlockRange()
         assert status.getMotorStatus() == 0
         assert (
-            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+            str(status) == "CHSesameBotMechStatus(Battery=100% (3.00V), motorStatus=0)"
         )
 
         status = CHSesameBotMechStatus(rawdata=bytes.fromhex("5503000000000102"))
         assert (
-            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+            str(status) == "CHSesameBotMechStatus(Battery=100% (3.00V), motorStatus=0)"
         )
 
     def test_CHSesameBotMechStatus_rawdata_unlocked(self):
         status = CHSesameBotMechStatus(rawdata="5503000000000104")
 
         assert status.getBatteryPrecentage() == 100.0
-        assert status.getBatteryVoltage() == 6.003519061583578
+        assert status.getBatteryVoltage() == 3.001759530791789
         assert not status.isInLockRange()
         assert status.isInUnlockRange()
         assert status.getMotorStatus() == 0
         assert (
-            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+            str(status) == "CHSesameBotMechStatus(Battery=100% (3.00V), motorStatus=0)"
         )
+
+    def test_CHSesameBotMechStatus_rawdata_lowpower(self):
+        status = CHSesameBotMechStatus(rawdata="3003000000000102")
+        assert status.getBatteryPrecentage() == 44
+        assert status.getBatteryVoltage() == 2.8715542521994135
+
+        status2 = CHSesameBotMechStatus(rawdata="4802000000000102")
+        assert status2.getBatteryPrecentage() == 0
 
 
 class TestCHSesameBotMechSettings:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -70,7 +70,7 @@ class TestCHSesameProtocolMechStatus:
         with pytest.raises(TypeError):
             CHSesameProtocolMechStatus(10)
 
-    def test_CHSesame2MechStatus(self):
+    def test_CHSesameProtocolMechStatus(self):
         status = CHSesameProtocolMechStatus(rawdata="60030080f3ff0002")
         assert status.isInLockRange()
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -8,6 +8,12 @@ from pysesameos2.helper import (
     CHProductModel,
     CHSesame2MechSettings,
     CHSesame2MechStatus,
+    CHSesameBotButtonMode,
+    CHSesameBotLockSecondsConfiguration,
+    CHSesameBotMechSettings,
+    CHSesameBotMechStatus,
+    CHSesameBotUserPreDir,
+    CHSesameProtocolMechStatus,
     HistoryTagHelper,
 )
 
@@ -55,6 +61,23 @@ class TestCHProductModel:
         assert CHProductModel.getByValue(0) is CHProductModel.SS2
 
 
+class TestCHSesameProtocolMechStatus:
+    def test_CHSesameProtocolMechStatus_raises_exception_on_emtry_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameProtocolMechStatus()
+
+    def test_CHSesameProtocolMechStatus_raises_exception_on_non_string_argument(self):
+        with pytest.raises(TypeError):
+            CHSesameProtocolMechStatus(10)
+
+    def test_CHSesame2MechStatus(self):
+        status = CHSesameProtocolMechStatus(rawdata="60030080f3ff0002")
+        assert status.getBatteryVoltage() == 6.0809384164222875
+
+        status = CHSesameProtocolMechStatus(rawdata=bytes.fromhex("60030080f3ff0002"))
+        assert status.getBatteryVoltage() == 6.0809384164222875
+
+
 class TestCHSesame2MechStatus:
     def test_CHSesame2MechStatus_raises_exception_on_emtry_arguments(self):
         with pytest.raises(TypeError):
@@ -74,6 +97,12 @@ class TestCHSesame2MechStatus:
         assert status.getTarget() == -32768
         assert status.isInLockRange()
         assert not status.isInUnlockRange()
+        assert (
+            str(status)
+            == "CHSesame2MechStatus(Battery=100% (6.08V), isInLockRange=True, isInUnlockRange=False, Position=-13)"
+        )
+
+        status = CHSesame2MechStatus(rawdata=bytes.fromhex("60030080f3ff0002"))
         assert (
             str(status)
             == "CHSesame2MechStatus(Battery=100% (6.08V), isInLockRange=True, isInUnlockRange=False, Position=-13)"
@@ -124,6 +153,96 @@ class TestCHSesame2MechSettings:
             str(setting)
             == "CHSesame2MechSettings(LockPosition=-17, UnlockPosition=284, isConfigured=True)"
         )
+
+
+class TestCHSesameBotMechStatus:
+    def test_CHSesameBotMechStatus_raises_exception_on_emtry_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBotMechStatus()
+
+    def test_CHSesameBotMechStatus_raises_exception_on_non_string_argument(self):
+        with pytest.raises(TypeError):
+            CHSesameBotMechStatus(10)
+
+    def test_CHSesameBotMechStatus_rawdata_locked(self):
+        status = CHSesameBotMechStatus(rawdata="5503000000000102")
+
+        assert status.getBatteryPrecentage() == 100.0
+        assert status.getBatteryVoltage() == 6.003519061583578
+        assert status.isInLockRange()
+        assert not status.isInUnlockRange()
+        assert status.getMotorStatus() == 0
+        assert (
+            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+        )
+
+        status = CHSesameBotMechStatus(rawdata=bytes.fromhex("5503000000000102"))
+        assert (
+            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+        )
+
+    def test_CHSesameBotMechStatus_rawdata_unlocked(self):
+        status = CHSesameBotMechStatus(rawdata="5503000000000104")
+
+        assert status.getBatteryPrecentage() == 100.0
+        assert status.getBatteryVoltage() == 6.003519061583578
+        assert not status.isInLockRange()
+        assert status.isInUnlockRange()
+        assert status.getMotorStatus() == 0
+        assert (
+            str(status) == "CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0)"
+        )
+
+
+class TestCHSesameBotMechSettings:
+    def test_CHSesameBotMechSettings_raises_exception_on_emtry_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBotMechSettings()
+
+    def test_CHSesameBotMechSettings_raises_exception_on_non_string_argument(self):
+        with pytest.raises(TypeError):
+            CHSesameBotMechSettings(10)
+
+    def test_CHSesameBotMechSettings(self):
+        setting = CHSesameBotMechSettings(
+            rawdata=bytes.fromhex("010a0a0a140f000000000000")
+        )
+
+        assert setting.getUserPrefDir() == CHSesameBotUserPreDir.reversed
+        assert setting.getLockSecConfig().getLockSec() == 10
+        assert setting.getLockSecConfig().getUnlockSec() == 10
+        assert setting.getLockSecConfig().getClickLockSec() == 10
+        assert setting.getLockSecConfig().getClickHoldSec() == 20
+        assert setting.getLockSecConfig().getClickUnlockSec() == 15
+        assert setting.getButtonMode() == CHSesameBotButtonMode.click
+
+        assert (
+            str(setting)
+            == "CHSesameBotMechSettings(userPrefDir=CHSesameBotUserPreDir.reversed, lockSec=10, unlockSec=10, clickLockSec=10, clickHoldSec=20, clickUnlockSec=15, buttonMode=CHSesameBotButtonMode.click)"
+        )
+
+
+class TestCHSesameBotLockSecondsConfiguration:
+    def test_CHSesameBotLockSecondsConfiguration_raises_exception_on_emtry_arguments(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            CHSesameBotLockSecondsConfiguration()
+
+    def test_CHSesameBotLockSecondsConfiguration_raises_exception_on_non_string_argument(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            CHSesameBotLockSecondsConfiguration(10)
+
+    def test_CHSesameBotLockSecondsConfiguration(self):
+        c = CHSesameBotLockSecondsConfiguration(rawdata="0a0a0a140f")
+
+        assert c.getLockSec() == 10
+        assert c.getUnlockSec() == 10
+        assert c.getClickLockSec() == 10
+        assert c.getClickHoldSec() == 20
+        assert c.getClickUnlockSec() == 15
 
 
 class TestHistoryTagHelper:


### PR DESCRIPTION
Thanks to [@Chabiichi](https://github.com/Chabiichi)-san, I was able to get one SESAME bot. His offer is very much appreciated.

This PR is the initial try to support SESAME bot. This should work anyway but I am still checking the stability.

I have two concerns at this point.

1. Looking at [the class reference](https://doc.candyhouse.co/ja/reference), I noticed that there are some pretty big differences between the iOS and Android SDKs. That is, in some classes, the implementation of the Android SDK directly holds byte data without using an easy-to-understand class. For instance, focusing on [`CHSesameBotMechSettings`](https://doc.candyhouse.co/ja/reference#chsesamebotmechsettings), the Android SDK implementation does not use [`CHSesameBotLockSecondsConfiguration`](https://doc.candyhouse.co/ja/reference#chsesamebotlocksecondsconfiguration).
Although the main reference for me is reverse engineering of the Android SDK, I have implemented some iOS-only classes (e.g., [`CHSesameBotLockSecondsConfiguration`](https://doc.candyhouse.co/ja/reference#chsesamebotlocksecondsconfiguration)) to organize the data easily for users.
2. In the official app, SESAME bot can only perform click operations and cannot be used to make complex parameter adjustments. However, according to the class reference, SESAME bot appears to be capable of a variety of actions and tuning (e.g., [`CHSesameBotUserPreDir`](https://doc.candyhouse.co/ja/reference#chsesamebotuserpredir), [`CHSesameBotLockSecondsConfiguration`](https://doc.candyhouse.co/ja/reference#chsesamebotlocksecondsconfiguration)).
Unfortunately, in reality, those parameters do not seem to be reflected in the actual operation. For instance, in the factory default settings, `lockSeconds` and `unlockSeconds` are set to 10 seconds each, but the arm is actually running for less than 10 seconds. For now, I leave it anyway and wait for the firmware updates!


solves #13