### PR TITLE
SESAME4 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pysesameos2
 
-_Unofficial Python Library to communicate with SESAME 3 series products via Bluetooth connection._
+_Unofficial Python Library to communicate with SESAME products via Bluetooth._
 
 [![PyPI](https://img.shields.io/pypi/v/pysesameos2)](https://pypi.python.org/pypi/pysesameos2)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pysesameos2)
@@ -11,7 +11,7 @@ _Unofficial Python Library to communicate with SESAME 3 series products via Blue
 
 ## Introduction
 
-This project aims to control smart devices running **Sesame OS2** via **Bluetooth connection**. If you want to control them via the cloud service, please check [pysesame3](https://github.com/mochipon/pysesame3).
+This project aims to control smart devices running **Sesame OS2** via **Bluetooth**. If you want to control them via the cloud service, please check [pysesame3](https://github.com/mochipon/pysesame3).
 
 To be honest, this is my first time to use [`Bleak`](https://github.com/hbldh/bleak) which provides an asynchronous, cross-platform Bluetooth API. PRs are heavily welcome.
 
@@ -26,6 +26,7 @@ To be honest, this is my first time to use [`Bleak`](https://github.com/hbldh/bl
 ## Supported devices
 
 - [SESAME 3](https://jp.candyhouse.co/products/sesame3)
+- [SESAME 4](https://jp.candyhouse.co/products/sesame4)
 - [SESAME bot](https://jp.candyhouse.co/products/sesame3-bot)
 
 ## Features
@@ -43,6 +44,26 @@ To be honest, this is my first time to use [`Bleak`](https://github.com/hbldh/bl
 ## Usage
 
 Please take a look at the [`example`](https://github.com/mochipon/pysesameos2/tree/main/example) directory.
+
+## Related Projects
+
+### Libraries
+| Name | Lang | Communication Method |
+----|----|----
+| [pysesame](https://github.com/trisk/pysesame) | Python | [Sesame API v1/v2](https://docs.candyhouse.co/v1.html)
+| [pysesame2](https://github.com/yagami-cerberus/pysesame2) | Python | [Sesame API v3](https://docs.candyhouse.co/)
+| [pysesame3](https://github.com/mochipon/pysesame3) | Python | [Web API](https://doc.candyhouse.co/ja/SesameAPI), [CognitoAuth (The official android SDK reverse-engineered)](https://doc.candyhouse.co/ja/android)
+| [pysesameos2](https://github.com/mochipon/pysesameos2) | Python | [Bluetooth](https://doc.candyhouse.co/ja/android)
+
+### Integrations
+| Name | Description | Communication Method |
+----|----|----
+| [doorman](https://github.com/jp7eph/doorman) | Control SESAME3 from Homebridge by MQTT | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [Doorlock](https://github.com/kishikawakatsumi/Doorlock) | iOS widget for Sesame 3 smart lock | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [gopy-sesame3](https://github.com/orangekame3/gopy-sesame3) | NFC (Felica) integration | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [homebridge-open-sesame](https://github.com/yasuoza/homebridge-open-sesame) | Homebridge plugin for SESAME3 | Cognito integration
+| [homebridge-sesame-os2](https://github.com/nzws/homebridge-sesame-os2) | Homebridge Plugin for SESAME OS2 (SESAME3) | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [sesame3-webhook](https://github.com/kunikada/sesame3-webhook) | Send SESAME3 status to specified url. (HTTP Post) | CognitoAuth (based on `pysesame3`)
 
 ## Credits & Thanks
 

--- a/example/connect.py
+++ b/example/connect.py
@@ -127,7 +127,7 @@ async def connect(scan_duration: int = 15):
     while True:
         val = await ainput("Action [lock/unlock/toggle/click]: ")
 
-        if device.productModel == CHProductModel.SS2:
+        if device.productModel in [CHProductModel.SS2, CHProductModel.SS4]:
             if val == "lock":
                 await device.lock(history_tag="My Script")
             elif val == "unlock":

--- a/pysesameos2/chsesame2.py
+++ b/pysesameos2/chsesame2.py
@@ -79,7 +79,6 @@ class CHSesame2(CHSesameLock):
     def __init__(self) -> None:
         """SESAME3 Device Specific Implementation."""
         super().__init__()
-        self.setProductModel(CHProductModel.SS2)
         self._rxBuffer = CHSesame2BleReceiver()
         self._txBuffer: Optional[CHSesame2BleTransmiter] = None
         self._mechStatus: Optional[CHSesame2MechStatus] = None

--- a/pysesameos2/chsesamebot.py
+++ b/pysesameos2/chsesamebot.py
@@ -80,7 +80,6 @@ class CHSesameBot(CHSesameLock):
     def __init__(self) -> None:
         """SESAME bot Device Specific Implementation."""
         super().__init__()
-        self.setProductModel(CHProductModel.SesameBot1)
         self._rxBuffer = CHSesame2BleReceiver()
         self._txBuffer: Optional[CHSesame2BleTransmiter] = None
         self._mechStatus: Optional[CHSesameBotMechStatus] = None

--- a/pysesameos2/helper.py
+++ b/pysesameos2/helper.py
@@ -29,6 +29,12 @@ class CHProductModel(Enum):
         "productType": 0,
         "deviceFactory": "CHSesame2",
     }
+    SS4: ProductData = {
+        "deviceModel": "sesame_4",
+        "isLocker": True,
+        "productType": 4,
+        "deviceFactory": "CHSesame2",
+    }
     SesameBot1: ProductData = {
         "deviceModel": "ssmbot_1",
         "isLocker": True,

--- a/tests/test_chsesame2.py
+++ b/tests/test_chsesame2.py
@@ -15,7 +15,11 @@ from pysesameos2.chsesame2 import CHSesame2, CHSesame2BleLoginResponse
 from pysesameos2.const import BleCommunicationType, CHSesame2Intention, CHSesame2Status
 from pysesameos2.crypto import BleCipher
 from pysesameos2.device import CHDeviceKey
-from pysesameos2.helper import CHSesame2MechSettings, CHSesame2MechStatus
+from pysesameos2.helper import (
+    CHProductModel,
+    CHSesame2MechSettings,
+    CHSesame2MechStatus,
+)
 
 if sys.version_info[:2] < (3, 8):
     from asynctest import patch
@@ -233,6 +237,7 @@ class TestCHSesame2:
     @pytest.mark.asyncio
     async def test_CHSesame2_onGattSesamePublish_mechStatus(self):
         s = CHSesame2()
+        s.setProductModel(CHProductModel.SS2)
 
         publish_payload = CHSesame2BlePublish(bytes.fromhex("5160030080f3ff0002"))
 

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -16,6 +16,7 @@ from pysesameos2.const import BleCommunicationType, CHSesame2Intention, CHSesame
 from pysesameos2.crypto import BleCipher
 from pysesameos2.device import CHDeviceKey
 from pysesameos2.helper import (
+    CHProductModel,
     CHSesameBotButtonMode,
     CHSesameBotMechSettings,
     CHSesameBotMechStatus,
@@ -227,6 +228,7 @@ class TestCHSesameBot:
     @pytest.mark.asyncio
     async def test_CHSesameBot_onGattSesamePublish_mechStatus(self):
         s = CHSesameBot()
+        s.setProductModel(CHProductModel.SesameBot1)
 
         publish_payload = CHSesame2BlePublish(bytes.fromhex("515503000000000102"))
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -30,6 +30,13 @@ class TestCHProductModel:
         assert ss2.productType() == 0
         assert ss2.deviceFactory().__name__ == "CHSesame2"
 
+    def test_CHProductModel_SS4(self):
+        ss2 = CHProductModel.SS4
+        assert ss2.deviceModel() == "sesame_4"
+        assert ss2.isLocker()
+        assert ss2.productType() == 4
+        assert ss2.deviceFactory().__name__ == "CHSesame2"
+
     def test_CHProductModel_WM2(self):
         wm2 = CHProductModel.WM2
         assert wm2.deviceModel() == "wm_2"


### PR DESCRIPTION
This PR aims to make this library support [SESAME 4](https://jp.candyhouse.co/products/sesame4).

Although [the documentation](https://doc.candyhouse.co/ja/reference) has not been updated, [the SDK has been updated](https://github.com/CANDY-HOUSE/SesameSDK_Android/commits/main). SESAME 4 can be controlled in exactly the same way as SESAME 3 in software, so we could implement it quickly.

**I hope to get feedback from users to see whether it works or not since I will not buy SESAME 4 for me.**