### PR TITLE
MQTT sample can't work properly

### DIFF
--- a/example/mqtt2sesame/mqtt2sesame.py
+++ b/example/mqtt2sesame/mqtt2sesame.py
@@ -187,6 +187,8 @@ def onMQTTMessage(client, userdata, msg: MQTTMessage) -> None:
 async def runner():
     global mqtt_client, config, cmd_queue, connected_devices
 
+    cmd_queue = asyncio.Queue()
+
     lwt_topic = "{}/LWT".format(config["mqtt"]["topic_prefix"])
     mqtt_client.will_set(lwt_topic, payload="offline", qos=1, retain=True)
     mqtt_client.on_message = onMQTTMessage

--- a/example/mqtt2sesame/mqtt2sesame.py
+++ b/example/mqtt2sesame/mqtt2sesame.py
@@ -177,7 +177,7 @@ def onMQTTMessage(client, userdata, msg: MQTTMessage) -> None:
 
     if not isinstance(uuid, str):
         raise TypeError("Failed to parse the device uuid from topic")
-    if cmd not in ["LOCK, UNLOCK"]:
+    if cmd not in ["LOCK", "UNLOCK"]:
         raise TypeError("Failed to parse command: {}".format(cmd))
 
     if cmd == "LOCK" or cmd == "UNLOCK":


### PR DESCRIPTION
MQTTのサンプルがv0.0.5のアップデート時に正しく動作しないようなコードに書き変わってしまっていたのでその修正です。

cmd_queueはasyncioのループ内で生成する必要がありました。
51行目でNoneを入れるとlintエラーが発生するので２回生成してます。

また、lintの問題がありますが、#59 の変更も取り込まないとBLEの状態変化をキャッチできません。
